### PR TITLE
feat: adds UnmarshalArgs - A function to unmarshal query args 

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -1,14 +1,169 @@
 package fastglue
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/valyala/fasthttp"
 )
+
+var (
+	bracketSplitter = regexp.MustCompile("\\[|\\]")
+
+	// ErrInvalidParam is returned when invalid data is provided to the ToJSON or Unmarshal function.
+	// Specifically, this will be returned when there is no equals sign present in the URL query parameter.
+	ErrInvalidParam = errors.New("qson: invalid url query param provided")
+)
+
+// UnmarshalArgs takes fasthttp args, converts given args to byte string and unmarshals to destination.
+// Known limitation: args-to-json conversion does not take array notations into account, treats array key as string.
+// eg: Legs[1]=Insights will be converted to json as follows:
+// {"Legs": {"1": "Insights"}}
+func UnmarshalArgs(args *fasthttp.Args, dst interface{}) error {
+	b, err := toJSON(args)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(b, dst)
+}
+
+// toJSON will turn a query string like:
+//   cat=1&bar%5Bone%5D%5Btwo%5D=2&bar[one][red]=112
+// Into a JSON object with all the data merged as nicely as
+// possible. Eg the example above would output:
+//   {"bar":{"one":{"two":2,"red":112}}}
+func toJSON(query *fasthttp.Args) ([]byte, error) {
+	var (
+		builder interface{} = make(map[string]interface{})
+	)
+
+	query.VisitAll(func(key, value []byte) {
+		tempMap, err := queryToMap(string(key), string(value))
+		if err != nil {
+			return
+		}
+		builder = merge(builder, tempMap)
+	})
+	return json.Marshal(builder)
+}
+
+// queryToMap turns something like a[b][c]=4 into
+//   map[string]interface{}{
+//     "a": map[string]interface{}{
+// 		  "b": map[string]interface{}{
+// 			  "c": 4,
+// 		  },
+// 	  },
+//   }
+func queryToMap(rawKey, rawValue string) (interface{}, error) {
+	pieces := bracketSplitter.Split(rawKey, -1)
+	key := pieces[0]
+
+	// If len==1 then rawKey has no [] chars and we can just
+	// decode this as key=value into {key: value}
+	if len(pieces) == 1 {
+		var value interface{}
+		// First we try parsing it as an int, bool, null, etc
+		err := json.Unmarshal([]byte(rawValue), &value)
+		if err != nil {
+			// If we got an error we try wrapping the value in
+			// quotes and processing it as a string
+			err = json.Unmarshal([]byte("\""+rawValue+"\""), &value)
+			if err != nil {
+				// If we can't decode as a string we return the err
+				return nil, err
+			}
+		}
+		return map[string]interface{}{
+			key: value,
+		}, nil
+	}
+
+	// If len > 1 then we have something like a[b][c]=2
+	// so we need to turn this into {"a": {"b": {"c": 2}}}
+	// To do this we break our key into two pieces:
+	//   a and b[c]
+	// and then we set {"a": queryToMap("b[c]", value)}
+	ret := make(map[string]interface{}, 0)
+	var err error
+
+	ret[key], err = queryToMap(buildNewKey(rawKey), rawValue)
+	if err != nil {
+		return nil, err
+	}
+
+	// When URL params have a set of empty brackets (eg a[]=1)
+	// it is assumed to be an array. This will get us the
+	// correct value for the array item and return it as an
+	// []interface{} so that it can be merged properly.
+	if pieces[1] == "" {
+		temp := ret[key].(map[string]interface{})
+		ret[key] = []interface{}{temp[""]}
+	}
+	return ret, nil
+}
+
+// buildNewKey will take something like:
+// origKey = "bar[one][two]"
+// pieces = [bar one two ]
+// and return "one[two]"
+func buildNewKey(origKey string) string {
+	pieces := bracketSplitter.Split(origKey, -1)
+	ret := origKey[len(pieces[0])+1:]
+	ret = ret[:len(pieces[1])] + ret[len(pieces[1])+1:]
+	return ret
+}
+
+// splitKeyAndValue splits a URL param at the last equal
+// sign and returns the two strings. If no equal sign is
+// found, the ErrInvalidParam error is returned.
+func splitKeyAndValue(param string) (string, string, error) {
+	li := strings.LastIndex(param, "=")
+	if li == -1 {
+		return "", "", ErrInvalidParam
+	}
+	return param[:li], param[li+1:], nil
+}
+
+// merge merges a with b if they are either both slices
+// or map[string]interface{} types. Otherwise it returns b.
+func merge(a interface{}, b interface{}) interface{} {
+	switch aT := a.(type) {
+	case map[string]interface{}:
+		return mergeMap(aT, b.(map[string]interface{}))
+	case []interface{}:
+		return mergeSlice(aT, b.([]interface{}))
+	default:
+		return b
+	}
+}
+
+// mergeMap merges a with b, attempting to merge any nested
+// values in nested maps but eventually overwriting anything
+// in a that can't be merged with whatever is in b.
+func mergeMap(a map[string]interface{}, b map[string]interface{}) map[string]interface{} {
+	for bK, bV := range b {
+		if _, ok := a[bK]; ok {
+			a[bK] = merge(a[bK], bV)
+		} else {
+			a[bK] = bV
+		}
+	}
+	return a
+}
+
+// mergeSlice merges a with b and returns the result.
+func mergeSlice(a []interface{}, b []interface{}) []interface{} {
+	a = append(a, b...)
+	return a
+}
 
 // ScanArgs takes a fasthttp.Args set, takes its keys and values
 // and applies them to a given struct using reflection. The field names

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,58 @@
+package fastglue
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+type callLog struct {
+	CallFrom             string         `json:"CallFrom"`
+	CallTo               string         `json:"CallTo"`
+	CallSid              string         `json:"CallSid"`
+	FlowID               int            `json:"flow_id"`
+	CallType             string         `json:"CallType"`
+	Direction            string         `json:"call_direction"`
+	TenantID             int            `json:"tenant_id"`
+	RecordingURL         string         `json:"RecordingUrl"`
+	ForwardedFrom        string         `json:"ForwardedFrom"`
+	Legs                 map[string]leg `json:"Legs"`
+	Insights             insight        `json:"Insights"`
+	DialCallStatus       string         `json:"DialCallStatus"`
+	DialWhomNumber       string         `json:"DialWhomNumber"`
+	DialCallDuration     int            `json:"DialCallDuration"`
+	RecordingAvailableBy string         `json:"RecordingAvailableBy"`
+	CallStatus           string         `json:"CallStatus"`
+	Tag                  string         `json:"tag"`
+	Type                 string         `json:"type"`
+	AgentEmail           string         `json:"agent_email"`
+	rawURL               string
+	Digits               string `json:"digits"`
+	Ref                  string
+}
+
+type leg struct {
+	Type           string  `json:"Type"`
+	Cause          string  `json:"Cause"`
+	Number         string  `json:"Number"`
+	CauseCode      string  `json:"CauseCode"`
+	OnCallDuration int     `json:"OnCallDuration"`
+	DialedNumber   string  `json:"dialed_number"`
+	DisconnectedBy string  `json:"DisconnectedBy"`
+	Insights       insight `json:"Insights"`
+}
+type insight struct {
+	DisconnectedBy  string  `json:"DisconnectedBy"`
+	DetailedStatus  string  `json:"DetailedStatus"`
+	RingingDuration float64 `json:"RingingDuration"`
+	DialCallStatus  string  `json:"DialCallStatus"`
+}
+
+func TestUnmarshalArgs(t *testing.T) {
+	args := fasthttp.AcquireArgs()
+	args.Parse(`Legs[1][Insights][Status]=completed&Legs[1][Insights][DetailedStatus]=CALL_COMPLETED&Legs[1][Insights][RingingDuration]=4.39&Insights[DialCallStatus]=completed`)
+	var o callLog
+	err := UnmarshalArgs(args, &o)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
UnmarshalArgs - A function to unmarshal query args to struct with json tags

Known limitation: args-to-json conversion does not take array notations into account, treats array key as string.
eg: Legs[1]=Insights will be converted to json as follows:
{Legs: {1: Insights}}